### PR TITLE
PB-1244: Adding ownership object replacing owner in Metadata structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/sirupsen/logrus v1.5.0
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sys v0.0.0-20210324051608-47abb6519492 // indirect
+	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
-	google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46
+	google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46 // indirect
 	google.golang.org/grpc v1.36.1
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,8 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZ
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
+golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/apis/v1/api.swagger.json
+++ b/pkg/apis/v1/api.swagger.json
@@ -3158,7 +3158,7 @@
         },
         "owner": {
           "type": "string",
-          "title": "owner of the object"
+          "title": "owner of the object. This field is deprecated, not to be used"
         },
         "labels": {
           "type": "object",
@@ -3166,6 +3166,10 @@
             "type": "string"
           },
           "title": "labels associated with the object"
+        },
+        "ownership": {
+          "$ref": "#/definitions/Ownership",
+          "title": "ownership of the object"
         }
       }
     },
@@ -3360,7 +3364,8 @@
           "title": "uid for the object"
         },
         "owner": {
-          "type": "string"
+          "type": "string",
+          "description": "owner of the object. This field is deprecated, not to be used\nTODO: Currently gRPC supports marking field as [deprecated=true]\nAs we need to access this field as part of migration to new Ownership\nmessage will not use the same for now."
         },
         "org_id": {
           "type": "string",
@@ -3385,6 +3390,10 @@
           "type": "string",
           "format": "int64",
           "title": "create time in sec"
+        },
+        "ownership": {
+          "$ref": "#/definitions/Ownership",
+          "title": "ownership of the object"
         }
       }
     },
@@ -3460,6 +3469,64 @@
           "$ref": "#/definitions/Metadata"
         }
       }
+    },
+    "Ownership": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Username of owner\nThe storage system uses the username taken from the token\nand is saved on this field. Only users with system administration\ncan edit this value."
+        },
+        "acls": {
+          "$ref": "#/definitions/OwnershipAccessControl",
+          "description": "Permissions to share objects which can be set by the owner."
+        }
+      },
+      "description": "Ownership information for objects(eg: backup object, schedule object).\nAdministrators are users who belong to the group `*`, meaning, every group."
+    },
+    "OwnershipAccessControl": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OwnershipAccessType"
+          },
+          "description": "Group access to objects which must match the group set in the\nauthorization token.\nCan be set by the owner or the system administrator only.\nPossible values are:\n1. no groups: Means no groups are given access.\n2. `[\"*\"]`: All groups are allowed.\n3. `[\"group1\", \"group2\"]`: Only certain groups are allowed. In this\nexample only\n_group1_ and _group2_ are allowed."
+        },
+        "collaborators": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/OwnershipAccessType"
+          },
+          "description": "Collaborator access to objects gives access to other user.\nMust be the username (unique id) set in the authorization token.\nThe owner or the administrator can set this value. Possible values\nare:\n1. no collaborators: Means no users are given access.\n2. `[\"*\"]`: All users are allowed.\n3. `[\"username1\", \"username2\"]`: Only certain usernames are allowed.\nIn this example only\n_username1_ and _username2_ are allowed."
+        },
+        "public": {
+          "$ref": "#/definitions/OwnershipPublicAccessControl",
+          "title": "Public access to objects may be assigned for access by the public\nuserd\nTODO: Instead of PublicAccessControl, can we just set '*' in\ncollaborators with required permision?"
+        }
+      }
+    },
+    "OwnershipAccessType": {
+      "type": "string",
+      "enum": [
+        "Invalid",
+        "Read",
+        "Write",
+        "Admin"
+      ],
+      "default": "Invalid",
+      "description": " - Read: Read access only and cannot affect the resource.\n - Write: Write access and can affect the resource.\nThis type automatically provides Read access also.\n - Admin: Administrator access.\nThis type automatically provides Read and Write access also."
+    },
+    "OwnershipPublicAccessControl": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/OwnershipAccessType",
+          "title": "AccessType declares which level of public access is allowed"
+        }
+      },
+      "title": "PublicAccessControl allows assigning public ownership"
     },
     "PXConfig": {
       "type": "object",

--- a/pkg/apis/v1/common.pb.go
+++ b/pkg/apis/v1/common.pb.go
@@ -64,11 +64,51 @@ func (LicenseType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_b12f1cda86a0f641, []int{0}
 }
 
+type Ownership_AccessType int32
+
+const (
+	Ownership_Invalid Ownership_AccessType = 0
+	// Read access only and cannot affect the resource.
+	Ownership_Read Ownership_AccessType = 1
+	// Write access and can affect the resource.
+	// This type automatically provides Read access also.
+	Ownership_Write Ownership_AccessType = 2
+	// Administrator access.
+	// This type automatically provides Read and Write access also.
+	Ownership_Admin Ownership_AccessType = 3
+)
+
+var Ownership_AccessType_name = map[int32]string{
+	0: "Invalid",
+	1: "Read",
+	2: "Write",
+	3: "Admin",
+}
+
+var Ownership_AccessType_value = map[string]int32{
+	"Invalid": 0,
+	"Read":    1,
+	"Write":   2,
+	"Admin":   3,
+}
+
+func (x Ownership_AccessType) String() string {
+	return proto.EnumName(Ownership_AccessType_name, int32(x))
+}
+
+func (Ownership_AccessType) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_b12f1cda86a0f641, []int{2, 0}
+}
+
 type Metadata struct {
 	// name of the object
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// uid for the object
-	Uid   string `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	Uid string `protobuf:"bytes,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	// owner of the object. This field is deprecated, not to be used
+	// TODO: Currently gRPC supports marking field as [deprecated=true]
+	// As we need to access this field as part of migration to new Ownership
+	// message will not use the same for now.
 	Owner string `protobuf:"bytes,3,opt,name=owner,proto3" json:"owner,omitempty"`
 	// organization uid
 	OrgId          string           `protobuf:"bytes,4,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
@@ -78,6 +118,8 @@ type Metadata struct {
 	Labels map[string]string `protobuf:"bytes,7,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// create time in sec
 	CreateTimeInSec int64 `protobuf:"varint,8,opt,name=create_time_in_sec,json=createTimeInSec,proto3" json:"create_time_in_sec,omitempty"`
+	// ownership of the object
+	Ownership *Ownership `protobuf:"bytes,9,opt,name=ownership,proto3" json:"ownership,omitempty"`
 }
 
 func (m *Metadata) Reset()         { *m = Metadata{} }
@@ -169,15 +211,24 @@ func (m *Metadata) GetCreateTimeInSec() int64 {
 	return 0
 }
 
+func (m *Metadata) GetOwnership() *Ownership {
+	if m != nil {
+		return m.Ownership
+	}
+	return nil
+}
+
 type CreateMetadata struct {
 	// name of the object
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// org id of the object
 	OrgId string `protobuf:"bytes,2,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
-	// owner of the object
+	// owner of the object. This field is deprecated, not to be used
 	Owner string `protobuf:"bytes,3,opt,name=owner,proto3" json:"owner,omitempty"`
 	// labels associated with the object
 	Labels map[string]string `protobuf:"bytes,4,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// ownership of the object
+	Ownership *Ownership `protobuf:"bytes,5,opt,name=ownership,proto3" json:"ownership,omitempty"`
 }
 
 func (m *CreateMetadata) Reset()         { *m = CreateMetadata{} }
@@ -241,49 +292,262 @@ func (m *CreateMetadata) GetLabels() map[string]string {
 	return nil
 }
 
+func (m *CreateMetadata) GetOwnership() *Ownership {
+	if m != nil {
+		return m.Ownership
+	}
+	return nil
+}
+
+// Ownership information for objects(eg: backup object, schedule object).
+// Administrators are users who belong to the group `*`, meaning, every group.
+type Ownership struct {
+	// Username of owner
+	// The storage system uses the username taken from the token
+	// and is saved on this field. Only users with system administration
+	// can edit this value.
+	Owner string `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
+	// Permissions to share objects which can be set by the owner.
+	Acls *Ownership_AccessControl `protobuf:"bytes,2,opt,name=acls,proto3" json:"acls,omitempty"`
+}
+
+func (m *Ownership) Reset()         { *m = Ownership{} }
+func (m *Ownership) String() string { return proto.CompactTextString(m) }
+func (*Ownership) ProtoMessage()    {}
+func (*Ownership) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b12f1cda86a0f641, []int{2}
+}
+func (m *Ownership) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Ownership) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Ownership.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Ownership) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Ownership.Merge(m, src)
+}
+func (m *Ownership) XXX_Size() int {
+	return m.Size()
+}
+func (m *Ownership) XXX_DiscardUnknown() {
+	xxx_messageInfo_Ownership.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Ownership proto.InternalMessageInfo
+
+func (m *Ownership) GetOwner() string {
+	if m != nil {
+		return m.Owner
+	}
+	return ""
+}
+
+func (m *Ownership) GetAcls() *Ownership_AccessControl {
+	if m != nil {
+		return m.Acls
+	}
+	return nil
+}
+
+// PublicAccessControl allows assigning public ownership
+type Ownership_PublicAccessControl struct {
+	// AccessType declares which level of public access is allowed
+	Type Ownership_AccessType `protobuf:"varint,1,opt,name=type,proto3,enum=Ownership_AccessType" json:"type,omitempty"`
+}
+
+func (m *Ownership_PublicAccessControl) Reset()         { *m = Ownership_PublicAccessControl{} }
+func (m *Ownership_PublicAccessControl) String() string { return proto.CompactTextString(m) }
+func (*Ownership_PublicAccessControl) ProtoMessage()    {}
+func (*Ownership_PublicAccessControl) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b12f1cda86a0f641, []int{2, 0}
+}
+func (m *Ownership_PublicAccessControl) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Ownership_PublicAccessControl) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Ownership_PublicAccessControl.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Ownership_PublicAccessControl) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Ownership_PublicAccessControl.Merge(m, src)
+}
+func (m *Ownership_PublicAccessControl) XXX_Size() int {
+	return m.Size()
+}
+func (m *Ownership_PublicAccessControl) XXX_DiscardUnknown() {
+	xxx_messageInfo_Ownership_PublicAccessControl.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Ownership_PublicAccessControl proto.InternalMessageInfo
+
+func (m *Ownership_PublicAccessControl) GetType() Ownership_AccessType {
+	if m != nil {
+		return m.Type
+	}
+	return Ownership_Invalid
+}
+
+type Ownership_AccessControl struct {
+	// Group access to objects which must match the group set in the
+	// authorization token.
+	// Can be set by the owner or the system administrator only.
+	// Possible values are:
+	// 1. no groups: Means no groups are given access.
+	// 2. `["*"]`: All groups are allowed.
+	// 3. `["group1", "group2"]`: Only certain groups are allowed. In this
+	// example only
+	// _group1_ and _group2_ are allowed.
+	Groups map[string]Ownership_AccessType `protobuf:"bytes,1,rep,name=groups,proto3" json:"groups,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=Ownership_AccessType"`
+	// Collaborator access to objects gives access to other user.
+	// Must be the username (unique id) set in the authorization token.
+	// The owner or the administrator can set this value. Possible values
+	// are:
+	// 1. no collaborators: Means no users are given access.
+	// 2. `["*"]`: All users are allowed.
+	// 3. `["username1", "username2"]`: Only certain usernames are allowed.
+	// In this example only
+	// _username1_ and _username2_ are allowed.
+	Collaborators map[string]Ownership_AccessType `protobuf:"bytes,2,rep,name=collaborators,proto3" json:"collaborators,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3,enum=Ownership_AccessType"`
+	// Public access to objects may be assigned for access by the public
+	// userd
+	// TODO: Instead of PublicAccessControl, can we just set '*' in
+	// collaborators with required permision?
+	Public *Ownership_PublicAccessControl `protobuf:"bytes,3,opt,name=public,proto3" json:"public,omitempty"`
+}
+
+func (m *Ownership_AccessControl) Reset()         { *m = Ownership_AccessControl{} }
+func (m *Ownership_AccessControl) String() string { return proto.CompactTextString(m) }
+func (*Ownership_AccessControl) ProtoMessage()    {}
+func (*Ownership_AccessControl) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b12f1cda86a0f641, []int{2, 1}
+}
+func (m *Ownership_AccessControl) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Ownership_AccessControl) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Ownership_AccessControl.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Ownership_AccessControl) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Ownership_AccessControl.Merge(m, src)
+}
+func (m *Ownership_AccessControl) XXX_Size() int {
+	return m.Size()
+}
+func (m *Ownership_AccessControl) XXX_DiscardUnknown() {
+	xxx_messageInfo_Ownership_AccessControl.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Ownership_AccessControl proto.InternalMessageInfo
+
+func (m *Ownership_AccessControl) GetGroups() map[string]Ownership_AccessType {
+	if m != nil {
+		return m.Groups
+	}
+	return nil
+}
+
+func (m *Ownership_AccessControl) GetCollaborators() map[string]Ownership_AccessType {
+	if m != nil {
+		return m.Collaborators
+	}
+	return nil
+}
+
+func (m *Ownership_AccessControl) GetPublic() *Ownership_PublicAccessControl {
+	if m != nil {
+		return m.Public
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterEnum("LicenseType", LicenseType_name, LicenseType_value)
+	proto.RegisterEnum("Ownership_AccessType", Ownership_AccessType_name, Ownership_AccessType_value)
 	proto.RegisterType((*Metadata)(nil), "Metadata")
 	proto.RegisterMapType((map[string]string)(nil), "Metadata.LabelsEntry")
 	proto.RegisterType((*CreateMetadata)(nil), "CreateMetadata")
 	proto.RegisterMapType((map[string]string)(nil), "CreateMetadata.LabelsEntry")
+	proto.RegisterType((*Ownership)(nil), "Ownership")
+	proto.RegisterType((*Ownership_PublicAccessControl)(nil), "Ownership.PublicAccessControl")
+	proto.RegisterType((*Ownership_AccessControl)(nil), "Ownership.AccessControl")
+	proto.RegisterMapType((map[string]Ownership_AccessType)(nil), "Ownership.AccessControl.CollaboratorsEntry")
+	proto.RegisterMapType((map[string]Ownership_AccessType)(nil), "Ownership.AccessControl.GroupsEntry")
 }
 
 func init() { proto.RegisterFile("pkg/apis/v1/common.proto", fileDescriptor_b12f1cda86a0f641) }
 
 var fileDescriptor_b12f1cda86a0f641 = []byte{
-	// 484 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x52, 0xcd, 0x6e, 0xd3, 0x40,
-	0x18, 0xcc, 0xc6, 0xf9, 0x69, 0x3f, 0x4b, 0xc1, 0x5a, 0x51, 0xc9, 0x0a, 0x92, 0x89, 0x7a, 0x0a,
-	0xa0, 0xda, 0xa2, 0xbd, 0xf0, 0x73, 0x22, 0xa5, 0x42, 0x91, 0x5a, 0x09, 0xa5, 0xa9, 0x90, 0xb8,
-	0x84, 0x8d, 0xfd, 0x61, 0x56, 0xb5, 0xbd, 0x96, 0xbd, 0x0e, 0xca, 0x5b, 0xf0, 0x18, 0x3c, 0x02,
-	0x57, 0x6e, 0x1c, 0x7b, 0xe4, 0x08, 0xce, 0x43, 0xc0, 0x11, 0xed, 0xda, 0x69, 0x82, 0x54, 0xc1,
-	0xa1, 0xb7, 0x99, 0xd1, 0xec, 0xe4, 0x9b, 0x89, 0xc1, 0x4e, 0x2f, 0x43, 0x8f, 0xa5, 0x3c, 0xf7,
-	0x16, 0x8f, 0x3d, 0x5f, 0xc4, 0xb1, 0x48, 0xdc, 0x34, 0x13, 0x52, 0xf4, 0xef, 0x87, 0x42, 0x84,
-	0x11, 0x7a, 0x9a, 0xcd, 0x8b, 0xf7, 0x9e, 0xe4, 0x31, 0xe6, 0x92, 0xc5, 0x69, 0x6d, 0x38, 0x08,
-	0xb9, 0xfc, 0x50, 0xcc, 0x5d, 0x5f, 0xc4, 0x5e, 0x28, 0x42, 0xb1, 0x71, 0x2a, 0xa6, 0x89, 0x46,
-	0x95, 0x7d, 0xff, 0x57, 0x13, 0x76, 0xce, 0x50, 0xb2, 0x80, 0x49, 0x46, 0x29, 0xb4, 0x12, 0x16,
-	0xa3, 0x4d, 0x06, 0x64, 0xb8, 0x3b, 0xd1, 0x98, 0x5a, 0x60, 0x14, 0x3c, 0xb0, 0x9b, 0x5a, 0x52,
-	0x90, 0xde, 0x85, 0xb6, 0xf8, 0x98, 0x60, 0x66, 0x1b, 0x5a, 0xab, 0x08, 0xdd, 0x83, 0x8e, 0xc8,
-	0xc2, 0x19, 0x0f, 0xec, 0x56, 0x2d, 0x67, 0xe1, 0x38, 0xa0, 0xcf, 0xc1, 0xf4, 0x33, 0x64, 0x12,
-	0x67, 0xea, 0x50, 0xbb, 0x3d, 0x20, 0x43, 0xf3, 0xb0, 0xef, 0x56, 0x2d, 0xdc, 0xf5, 0x6d, 0xee,
-	0x74, 0xdd, 0x62, 0x02, 0x95, 0x5d, 0x09, 0xf4, 0x25, 0x58, 0x11, 0xcb, 0xe5, 0xac, 0x48, 0x83,
-	0xeb, 0x84, 0xce, 0x7f, 0x13, 0x7a, 0xea, 0xcd, 0x85, 0x7e, 0xa2, 0x53, 0x0e, 0xa0, 0x13, 0xb1,
-	0x39, 0x46, 0xb9, 0xdd, 0x1d, 0x18, 0x43, 0xf3, 0x70, 0xcf, 0x5d, 0x17, 0x76, 0x4f, 0xb5, 0x7e,
-	0x92, 0xc8, 0x6c, 0x39, 0xa9, 0x4d, 0xf4, 0x11, 0xd0, 0xad, 0x8b, 0x67, 0x3c, 0x99, 0xe5, 0xe8,
-	0xdb, 0x3b, 0x03, 0x32, 0x34, 0x26, 0x77, 0x36, 0xc7, 0x8d, 0x93, 0x73, 0xf4, 0xfb, 0x4f, 0xc1,
-	0xdc, 0xca, 0x50, 0x63, 0x5d, 0xe2, 0xb2, 0xde, 0x4f, 0x41, 0x35, 0xd6, 0x82, 0x45, 0x05, 0xd6,
-	0x03, 0x56, 0xe4, 0x59, 0xf3, 0x09, 0xd9, 0xff, 0x4a, 0xa0, 0x77, 0xac, 0xe3, 0xfe, 0xb9, 0xff,
-	0x66, 0xd7, 0xe6, 0xf6, 0xae, 0x37, 0xff, 0x09, 0x47, 0xd7, 0x55, 0x5b, 0xba, 0xea, 0x3d, 0xf7,
-	0xef, 0x5f, 0xb8, 0xa9, 0xf0, 0x2d, 0x3a, 0x3c, 0x7c, 0x07, 0xe6, 0x29, 0xf7, 0x31, 0xc9, 0x71,
-	0xba, 0x4c, 0x91, 0x9a, 0xd0, 0x1d, 0x27, 0x0b, 0x16, 0xf1, 0xc0, 0x6a, 0xd0, 0x5d, 0x68, 0x4f,
-	0x33, 0xce, 0x22, 0x8b, 0xd0, 0x1e, 0xc0, 0x49, 0x22, 0x31, 0x4b, 0x33, 0x9e, 0xa3, 0xd5, 0x54,
-	0xfc, 0x22, 0x67, 0x21, 0x8e, 0x58, 0x8e, 0x81, 0x65, 0xd0, 0x2e, 0x18, 0xe3, 0xd1, 0x99, 0xd5,
-	0x52, 0xe0, 0xc5, 0x9b, 0x73, 0xab, 0xad, 0xc0, 0xab, 0xe3, 0xd7, 0x56, 0x67, 0xf4, 0xe0, 0xf7,
-	0x4f, 0x87, 0x7c, 0x2e, 0x1d, 0xf2, 0xa5, 0x74, 0xc8, 0xb7, 0xd2, 0x21, 0x57, 0xa5, 0x43, 0x7e,
-	0x94, 0x0e, 0xf9, 0xb4, 0x72, 0x1a, 0x57, 0x2b, 0xa7, 0xf1, 0x7d, 0xe5, 0x34, 0xde, 0x1a, 0x2c,
-	0xe5, 0xf3, 0x8e, 0xfe, 0x16, 0x8e, 0xfe, 0x04, 0x00, 0x00, 0xff, 0xff, 0x19, 0x92, 0xa3, 0x0a,
-	0x3d, 0x03, 0x00, 0x00,
+	// 698 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x54, 0xc1, 0x6e, 0xd3, 0x4a,
+	0x14, 0xcd, 0xc4, 0x4e, 0xda, 0x5c, 0xab, 0x79, 0xd6, 0x3c, 0x2a, 0x59, 0x41, 0x32, 0x51, 0xc5,
+	0x22, 0xa5, 0xd4, 0x11, 0xa9, 0x84, 0x28, 0xb0, 0xa0, 0x0d, 0x55, 0x15, 0xa9, 0x15, 0xc5, 0x6d,
+	0x55, 0x89, 0x4d, 0x98, 0xd8, 0x83, 0x3b, 0xaa, 0xe3, 0xb1, 0x6c, 0xa7, 0x28, 0x6b, 0x7e, 0x80,
+	0x5f, 0x60, 0xc7, 0x27, 0xf0, 0x09, 0x2c, 0x2b, 0x56, 0x2c, 0x21, 0x5d, 0xf2, 0x03, 0x2c, 0xd1,
+	0x8c, 0x9d, 0xda, 0x51, 0x53, 0xd8, 0xc0, 0xee, 0xde, 0xeb, 0x73, 0xcf, 0x9c, 0x73, 0xae, 0x64,
+	0x30, 0xc2, 0x33, 0xaf, 0x4d, 0x42, 0x16, 0xb7, 0xcf, 0x1f, 0xb4, 0x1d, 0x3e, 0x1c, 0xf2, 0xc0,
+	0x0a, 0x23, 0x9e, 0xf0, 0xc6, 0x1d, 0x8f, 0x73, 0xcf, 0xa7, 0x6d, 0xd9, 0x0d, 0x46, 0x6f, 0xda,
+	0x09, 0x1b, 0xd2, 0x38, 0x21, 0xc3, 0x30, 0x03, 0xac, 0x7b, 0x2c, 0x39, 0x1d, 0x0d, 0x2c, 0x87,
+	0x0f, 0xdb, 0x1e, 0xf7, 0x78, 0x8e, 0x14, 0x9d, 0x6c, 0x64, 0x95, 0xc2, 0x57, 0x3e, 0x28, 0xb0,
+	0xb8, 0x4f, 0x13, 0xe2, 0x92, 0x84, 0x60, 0x0c, 0x6a, 0x40, 0x86, 0xd4, 0x40, 0x4d, 0xd4, 0xaa,
+	0xd9, 0xb2, 0xc6, 0x3a, 0x28, 0x23, 0xe6, 0x1a, 0x65, 0x39, 0x12, 0x25, 0xbe, 0x05, 0x15, 0xfe,
+	0x36, 0xa0, 0x91, 0xa1, 0xc8, 0x59, 0xda, 0xe0, 0x65, 0xa8, 0xf2, 0xc8, 0xeb, 0x33, 0xd7, 0x50,
+	0xb3, 0x71, 0xe4, 0xf5, 0x5c, 0xfc, 0x04, 0x34, 0x27, 0xa2, 0x24, 0xa1, 0x7d, 0x21, 0xd4, 0xa8,
+	0x34, 0x51, 0x4b, 0xeb, 0x34, 0xac, 0xd4, 0x85, 0x35, 0xd5, 0x66, 0x1d, 0x4d, 0x5d, 0xd8, 0x90,
+	0xc2, 0xc5, 0x00, 0x3f, 0x07, 0xdd, 0x27, 0x71, 0xd2, 0x1f, 0x85, 0xee, 0x15, 0x43, 0xf5, 0x8f,
+	0x0c, 0x75, 0xb1, 0x73, 0x2c, 0x57, 0x24, 0xcb, 0x3a, 0x54, 0x7d, 0x32, 0xa0, 0x7e, 0x6c, 0x2c,
+	0x34, 0x95, 0x96, 0xd6, 0x59, 0xb6, 0xa6, 0x86, 0xad, 0x3d, 0x39, 0xdf, 0x09, 0x92, 0x68, 0x6c,
+	0x67, 0x20, 0xbc, 0x06, 0xb8, 0xa0, 0xb8, 0xcf, 0x82, 0x7e, 0x4c, 0x1d, 0x63, 0xb1, 0x89, 0x5a,
+	0x8a, 0xfd, 0x5f, 0x2e, 0xae, 0x17, 0x1c, 0x52, 0x07, 0xb7, 0xa0, 0x26, 0xed, 0xc7, 0xa7, 0x2c,
+	0x34, 0x6a, 0x52, 0x1a, 0x58, 0x2f, 0xa6, 0x13, 0x3b, 0xff, 0xd8, 0xd8, 0x04, 0xad, 0xf0, 0x9a,
+	0x88, 0xf5, 0x8c, 0x8e, 0xb3, 0xa4, 0x45, 0x29, 0x62, 0x3d, 0x27, 0xfe, 0x88, 0x66, 0x51, 0xa7,
+	0xcd, 0xe3, 0xf2, 0x23, 0xb4, 0xf2, 0x03, 0x41, 0xbd, 0x2b, 0x1f, 0xfe, 0xed, 0xa5, 0xf2, 0x0b,
+	0x94, 0x8b, 0x17, 0x98, 0x7f, 0xae, 0x8d, 0xab, 0x50, 0x54, 0x19, 0xca, 0x6d, 0x6b, 0xf6, 0x85,
+	0xb9, 0xd1, 0xcc, 0xb8, 0xad, 0xfc, 0x23, 0xb7, 0x5f, 0x54, 0xa8, 0x5d, 0x71, 0xe6, 0xea, 0x51,
+	0x51, 0xfd, 0x7d, 0x50, 0x89, 0xe3, 0xc7, 0x72, 0x59, 0xeb, 0x18, 0xb9, 0x06, 0x6b, 0xcb, 0x71,
+	0x68, 0x1c, 0x77, 0x79, 0x90, 0x44, 0xdc, 0xb7, 0x25, 0xaa, 0xf1, 0x0c, 0xfe, 0x3f, 0x18, 0x0d,
+	0x7c, 0xe6, 0xcc, 0x7c, 0xc4, 0xab, 0xa0, 0x26, 0xe3, 0x30, 0xcd, 0xb0, 0xde, 0x59, 0xbe, 0x46,
+	0x72, 0x34, 0x0e, 0xa9, 0x2d, 0x21, 0x8d, 0x77, 0x0a, 0x2c, 0xcd, 0x2e, 0x3f, 0x85, 0xaa, 0x17,
+	0xf1, 0x51, 0x18, 0x1b, 0x48, 0xe6, 0x77, 0xf7, 0x26, 0x0d, 0xd6, 0xae, 0x84, 0x65, 0x41, 0xa6,
+	0x3b, 0xf8, 0x25, 0x2c, 0x39, 0xdc, 0xf7, 0xc9, 0x80, 0x47, 0x24, 0xe1, 0x91, 0x30, 0x22, 0x48,
+	0xd6, 0x6e, 0x24, 0xe9, 0x16, 0xd1, 0x29, 0xd7, 0x2c, 0x03, 0x7e, 0x08, 0xd5, 0x50, 0x9a, 0x94,
+	0x77, 0xd6, 0x3a, 0x66, 0x81, 0x6b, 0x8e, 0x7b, 0x3b, 0x43, 0x37, 0x0e, 0x40, 0x2b, 0x28, 0x9c,
+	0x73, 0xa9, 0xb5, 0xe2, 0xa5, 0x6e, 0xcc, 0x29, 0x3f, 0x60, 0xe3, 0x04, 0xf0, 0x75, 0xb9, 0x7f,
+	0x81, 0x78, 0x65, 0x13, 0x20, 0xff, 0x80, 0x35, 0x58, 0xe8, 0x05, 0xe7, 0xc4, 0x67, 0xae, 0x5e,
+	0xc2, 0x8b, 0xa0, 0xda, 0x94, 0xb8, 0x3a, 0xc2, 0x35, 0xa8, 0x9c, 0x44, 0x2c, 0xa1, 0x7a, 0x59,
+	0x94, 0x5b, 0xee, 0x90, 0x05, 0xba, 0x72, 0xef, 0x35, 0x68, 0x7b, 0xcc, 0xa1, 0x41, 0x4c, 0xaf,
+	0xef, 0xd6, 0xa0, 0x72, 0x14, 0x31, 0xe2, 0xeb, 0x08, 0xd7, 0x01, 0x76, 0x82, 0x84, 0x46, 0x61,
+	0xc4, 0x62, 0xc1, 0x50, 0x07, 0x38, 0x8e, 0x89, 0x47, 0xb7, 0x49, 0x4c, 0x5d, 0x5d, 0xc1, 0x0b,
+	0xa0, 0xf4, 0xb6, 0xf7, 0x75, 0x55, 0x14, 0x5b, 0x27, 0x87, 0x7a, 0x45, 0x14, 0xbb, 0xdd, 0x03,
+	0xbd, 0xba, 0xbd, 0xfa, 0xf3, 0xbb, 0x89, 0x3e, 0x4e, 0x4c, 0xf4, 0x69, 0x62, 0xa2, 0xcf, 0x13,
+	0x13, 0x5d, 0x4c, 0x4c, 0xf4, 0x6d, 0x62, 0xa2, 0xf7, 0x97, 0x66, 0xe9, 0xe2, 0xd2, 0x2c, 0x7d,
+	0xbd, 0x34, 0x4b, 0xaf, 0x14, 0x12, 0xb2, 0x41, 0x55, 0xfe, 0xb4, 0x36, 0x7e, 0x05, 0x00, 0x00,
+	0xff, 0xff, 0xdd, 0xfd, 0xe1, 0x14, 0xe6, 0x05, 0x00, 0x00,
 }
 
 func (this *Metadata) Equal(that interface{}) bool {
@@ -334,6 +598,9 @@ func (this *Metadata) Equal(that interface{}) bool {
 	if this.CreateTimeInSec != that1.CreateTimeInSec {
 		return false
 	}
+	if !this.Ownership.Equal(that1.Ownership) {
+		return false
+	}
 	return true
 }
 func (this *CreateMetadata) Equal(that interface{}) bool {
@@ -372,6 +639,100 @@ func (this *CreateMetadata) Equal(that interface{}) bool {
 			return false
 		}
 	}
+	if !this.Ownership.Equal(that1.Ownership) {
+		return false
+	}
+	return true
+}
+func (this *Ownership) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Ownership)
+	if !ok {
+		that2, ok := that.(Ownership)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Owner != that1.Owner {
+		return false
+	}
+	if !this.Acls.Equal(that1.Acls) {
+		return false
+	}
+	return true
+}
+func (this *Ownership_PublicAccessControl) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Ownership_PublicAccessControl)
+	if !ok {
+		that2, ok := that.(Ownership_PublicAccessControl)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Type != that1.Type {
+		return false
+	}
+	return true
+}
+func (this *Ownership_AccessControl) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Ownership_AccessControl)
+	if !ok {
+		that2, ok := that.(Ownership_AccessControl)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Groups) != len(that1.Groups) {
+		return false
+	}
+	for i := range this.Groups {
+		if this.Groups[i] != that1.Groups[i] {
+			return false
+		}
+	}
+	if len(this.Collaborators) != len(that1.Collaborators) {
+		return false
+	}
+	for i := range this.Collaborators {
+		if this.Collaborators[i] != that1.Collaborators[i] {
+			return false
+		}
+	}
+	if !this.Public.Equal(that1.Public) {
+		return false
+	}
 	return true
 }
 func (m *Metadata) Marshal() (dAtA []byte, err error) {
@@ -394,6 +755,18 @@ func (m *Metadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Ownership != nil {
+		{
+			size, err := m.Ownership.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCommon(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x4a
+	}
 	if m.CreateTimeInSec != 0 {
 		i = encodeVarintCommon(dAtA, i, uint64(m.CreateTimeInSec))
 		i--
@@ -493,6 +866,18 @@ func (m *CreateMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Ownership != nil {
+		{
+			size, err := m.Ownership.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCommon(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
 	if len(m.Labels) > 0 {
 		for k := range m.Labels {
 			v := m.Labels[k]
@@ -536,6 +921,145 @@ func (m *CreateMetadata) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *Ownership) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Ownership) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Ownership) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Acls != nil {
+		{
+			size, err := m.Acls.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCommon(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Owner) > 0 {
+		i -= len(m.Owner)
+		copy(dAtA[i:], m.Owner)
+		i = encodeVarintCommon(dAtA, i, uint64(len(m.Owner)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Ownership_PublicAccessControl) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Ownership_PublicAccessControl) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Ownership_PublicAccessControl) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Type != 0 {
+		i = encodeVarintCommon(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Ownership_AccessControl) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Ownership_AccessControl) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Ownership_AccessControl) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Public != nil {
+		{
+			size, err := m.Public.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintCommon(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Collaborators) > 0 {
+		for k := range m.Collaborators {
+			v := m.Collaborators[k]
+			baseI := i
+			i = encodeVarintCommon(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintCommon(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintCommon(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Groups) > 0 {
+		for k := range m.Groups {
+			v := m.Groups[k]
+			baseI := i
+			i = encodeVarintCommon(dAtA, i, uint64(v))
+			i--
+			dAtA[i] = 0x10
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintCommon(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintCommon(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintCommon(dAtA []byte, offset int, v uint64) int {
 	offset -= sovCommon(v)
 	base := offset
@@ -570,6 +1094,9 @@ func NewPopulatedMetadata(r randyCommon, easy bool) *Metadata {
 	if r.Intn(2) == 0 {
 		this.CreateTimeInSec *= -1
 	}
+	if r.Intn(5) != 0 {
+		this.Ownership = NewPopulatedOwnership(r, easy)
+	}
 	if !easy && r.Intn(10) != 0 {
 	}
 	return this
@@ -586,6 +1113,52 @@ func NewPopulatedCreateMetadata(r randyCommon, easy bool) *CreateMetadata {
 		for i := 0; i < v2; i++ {
 			this.Labels[randStringCommon(r)] = randStringCommon(r)
 		}
+	}
+	if r.Intn(5) != 0 {
+		this.Ownership = NewPopulatedOwnership(r, easy)
+	}
+	if !easy && r.Intn(10) != 0 {
+	}
+	return this
+}
+
+func NewPopulatedOwnership(r randyCommon, easy bool) *Ownership {
+	this := &Ownership{}
+	this.Owner = string(randStringCommon(r))
+	if r.Intn(5) != 0 {
+		this.Acls = NewPopulatedOwnership_AccessControl(r, easy)
+	}
+	if !easy && r.Intn(10) != 0 {
+	}
+	return this
+}
+
+func NewPopulatedOwnership_PublicAccessControl(r randyCommon, easy bool) *Ownership_PublicAccessControl {
+	this := &Ownership_PublicAccessControl{}
+	this.Type = Ownership_AccessType([]int32{0, 1, 2, 3}[r.Intn(4)])
+	if !easy && r.Intn(10) != 0 {
+	}
+	return this
+}
+
+func NewPopulatedOwnership_AccessControl(r randyCommon, easy bool) *Ownership_AccessControl {
+	this := &Ownership_AccessControl{}
+	if r.Intn(5) != 0 {
+		v3 := r.Intn(10)
+		this.Groups = make(map[string]Ownership_AccessType)
+		for i := 0; i < v3; i++ {
+			this.Groups[randStringCommon(r)] = Ownership_AccessType([]int32{0, 1, 2, 3}[r.Intn(4)])
+		}
+	}
+	if r.Intn(5) != 0 {
+		v4 := r.Intn(10)
+		this.Collaborators = make(map[string]Ownership_AccessType)
+		for i := 0; i < v4; i++ {
+			this.Collaborators[randStringCommon(r)] = Ownership_AccessType([]int32{0, 1, 2, 3}[r.Intn(4)])
+		}
+	}
+	if r.Intn(5) != 0 {
+		this.Public = NewPopulatedOwnership_PublicAccessControl(r, easy)
 	}
 	if !easy && r.Intn(10) != 0 {
 	}
@@ -611,9 +1184,9 @@ func randUTF8RuneCommon(r randyCommon) rune {
 	return rune(ru + 61)
 }
 func randStringCommon(r randyCommon) string {
-	v3 := r.Intn(100)
-	tmps := make([]rune, v3)
-	for i := 0; i < v3; i++ {
+	v5 := r.Intn(100)
+	tmps := make([]rune, v5)
+	for i := 0; i < v5; i++ {
 		tmps[i] = randUTF8RuneCommon(r)
 	}
 	return string(tmps)
@@ -635,11 +1208,11 @@ func randFieldCommon(dAtA []byte, r randyCommon, fieldNumber int, wire int) []by
 	switch wire {
 	case 0:
 		dAtA = encodeVarintPopulateCommon(dAtA, uint64(key))
-		v4 := r.Int63()
+		v6 := r.Int63()
 		if r.Intn(2) == 0 {
-			v4 *= -1
+			v6 *= -1
 		}
-		dAtA = encodeVarintPopulateCommon(dAtA, uint64(v4))
+		dAtA = encodeVarintPopulateCommon(dAtA, uint64(v6))
 	case 1:
 		dAtA = encodeVarintPopulateCommon(dAtA, uint64(key))
 		dAtA = append(dAtA, byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)), byte(r.Intn(256)))
@@ -705,6 +1278,10 @@ func (m *Metadata) Size() (n int) {
 	if m.CreateTimeInSec != 0 {
 		n += 1 + sovCommon(uint64(m.CreateTimeInSec))
 	}
+	if m.Ownership != nil {
+		l = m.Ownership.Size()
+		n += 1 + l + sovCommon(uint64(l))
+	}
 	return n
 }
 
@@ -733,6 +1310,68 @@ func (m *CreateMetadata) Size() (n int) {
 			mapEntrySize := 1 + len(k) + sovCommon(uint64(len(k))) + 1 + len(v) + sovCommon(uint64(len(v)))
 			n += mapEntrySize + 1 + sovCommon(uint64(mapEntrySize))
 		}
+	}
+	if m.Ownership != nil {
+		l = m.Ownership.Size()
+		n += 1 + l + sovCommon(uint64(l))
+	}
+	return n
+}
+
+func (m *Ownership) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Owner)
+	if l > 0 {
+		n += 1 + l + sovCommon(uint64(l))
+	}
+	if m.Acls != nil {
+		l = m.Acls.Size()
+		n += 1 + l + sovCommon(uint64(l))
+	}
+	return n
+}
+
+func (m *Ownership_PublicAccessControl) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Type != 0 {
+		n += 1 + sovCommon(uint64(m.Type))
+	}
+	return n
+}
+
+func (m *Ownership_AccessControl) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Groups) > 0 {
+		for k, v := range m.Groups {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovCommon(uint64(len(k))) + 1 + sovCommon(uint64(v))
+			n += mapEntrySize + 1 + sovCommon(uint64(mapEntrySize))
+		}
+	}
+	if len(m.Collaborators) > 0 {
+		for k, v := range m.Collaborators {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovCommon(uint64(len(k))) + 1 + sovCommon(uint64(v))
+			n += mapEntrySize + 1 + sovCommon(uint64(mapEntrySize))
+		}
+	}
+	if m.Public != nil {
+		l = m.Public.Size()
+		n += 1 + l + sovCommon(uint64(l))
 	}
 	return n
 }
@@ -1118,6 +1757,42 @@ func (m *Metadata) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 9:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ownership", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Ownership == nil {
+				m.Ownership = &Ownership{}
+			}
+			if err := m.Ownership.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipCommon(dAtA[iNdEx:])
@@ -1390,6 +2065,541 @@ func (m *CreateMetadata) Unmarshal(dAtA []byte) error {
 				}
 			}
 			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ownership", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Ownership == nil {
+				m.Ownership = &Ownership{}
+			}
+			if err := m.Ownership.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCommon(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Ownership) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCommon
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Ownership: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Ownership: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Owner", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Owner = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Acls", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Acls == nil {
+				m.Acls = &Ownership_AccessControl{}
+			}
+			if err := m.Acls.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCommon(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Ownership_PublicAccessControl) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCommon
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PublicAccessControl: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PublicAccessControl: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= Ownership_AccessType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCommon(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Ownership_AccessControl) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCommon
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AccessControl: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AccessControl: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Groups", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Groups == nil {
+				m.Groups = make(map[string]Ownership_AccessType)
+			}
+			var mapkey string
+			var mapvalue Ownership_AccessType
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowCommon
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowCommon
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthCommon
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthCommon
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowCommon
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapvalue |= Ownership_AccessType(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipCommon(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthCommon
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Groups[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Collaborators", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Collaborators == nil {
+				m.Collaborators = make(map[string]Ownership_AccessType)
+			}
+			var mapkey string
+			var mapvalue Ownership_AccessType
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowCommon
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowCommon
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthCommon
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthCommon
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowCommon
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						mapvalue |= Ownership_AccessType(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipCommon(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return ErrInvalidLengthCommon
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Collaborators[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Public", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCommon
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCommon
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCommon
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Public == nil {
+				m.Public = &Ownership_PublicAccessControl{}
+			}
+			if err := m.Public.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/pkg/apis/v1/common.proto
+++ b/pkg/apis/v1/common.proto
@@ -28,6 +28,10 @@ message Metadata {
     string name = 1;
     // uid for the object
     string uid = 2;
+    // owner of the object. This field is deprecated, not to be used
+    // TODO: Currently gRPC supports marking field as [deprecated=true]
+    // As we need to access this field as part of migration to new Ownership
+    // message will not use the same for now.
     string owner = 3;
     // organization uid
     string org_id = 4;
@@ -37,6 +41,8 @@ message Metadata {
     map<string, string> labels = 7;
     // create time in sec
     int64 create_time_in_sec = 8;
+    // ownership of the object
+    Ownership ownership = 9;
 }
 
 message CreateMetadata {
@@ -44,8 +50,67 @@ message CreateMetadata {
     string name = 1;
     // org id of the object
     string org_id = 2;
-    // owner of the object
+    // owner of the object. This field is deprecated, not to be used
     string owner = 3;
     // labels associated with the object
     map<string, string> labels = 4;
+    // ownership of the object
+    Ownership ownership = 5;
+}
+
+// Ownership information for objects(eg: backup object, schedule object).
+// Administrators are users who belong to the group `*`, meaning, every group.
+message Ownership {
+    enum AccessType {
+        Invalid = 0;
+        // Read access only and cannot affect the resource.
+        Read = 1;
+        // Write access and can affect the resource.
+        // This type automatically provides Read access also.
+        Write = 2;
+        // Administrator access.
+        // This type automatically provides Read and Write access also.
+        Admin = 3;
+    }
+    // PublicAccessControl allows assigning public ownership
+    message PublicAccessControl {
+        // AccessType declares which level of public access is allowed
+        AccessType type = 1;
+    }
+
+    message AccessControl {
+        // Group access to objects which must match the group set in the
+        // authorization token.
+        // Can be set by the owner or the system administrator only.
+        // Possible values are:
+        // 1. no groups: Means no groups are given access.
+        // 2. `["*"]`: All groups are allowed.
+        // 3. `["group1", "group2"]`: Only certain groups are allowed. In this
+        // example only
+        // _group1_ and _group2_ are allowed.
+        map<string, AccessType> groups = 1;
+        // Collaborator access to objects gives access to other user.
+        // Must be the username (unique id) set in the authorization token.
+        // The owner or the administrator can set this value. Possible values
+        // are:
+        // 1. no collaborators: Means no users are given access.
+        // 2. `["*"]`: All users are allowed.
+        // 3. `["username1", "username2"]`: Only certain usernames are allowed.
+        // In this example only
+        // _username1_ and _username2_ are allowed.
+        map<string, AccessType> collaborators = 2;
+        // Public access to objects may be assigned for access by the public
+        // userd
+        // TODO: Instead of PublicAccessControl, can we just set '*' in
+        // collaborators with required permision?
+        PublicAccessControl public = 3;
+    }
+
+    // Username of owner
+    // The storage system uses the username taken from the token
+    // and is saved on this field. Only users with system administration
+    // can edit this value.
+    string owner = 1;
+    // Permissions to share objects which can be set by the owner.
+    AccessControl acls = 2;
 }

--- a/pkg/apis/v1/commonpb_test.go
+++ b/pkg/apis/v1/commonpb_test.go
@@ -133,6 +133,174 @@ func TestCreateMetadataMarshalTo(t *testing.T) {
 	}
 }
 
+func TestOwnershipProto(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership(popr, false)
+	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership{}
+	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	littlefuzz := make([]byte, len(dAtA))
+	copy(littlefuzz, dAtA)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+	if len(littlefuzz) > 0 {
+		fuzzamount := 100
+		for i := 0; i < fuzzamount; i++ {
+			littlefuzz[popr.Intn(len(littlefuzz))] = byte(popr.Intn(256))
+			littlefuzz = append(littlefuzz, byte(popr.Intn(256)))
+		}
+		// shouldn't panic
+		_ = github_com_gogo_protobuf_proto.Unmarshal(littlefuzz, msg)
+	}
+}
+
+func TestOwnershipMarshalTo(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership(popr, false)
+	size := p.Size()
+	dAtA := make([]byte, size)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	_, err := p.MarshalTo(dAtA)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership{}
+	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnership_PublicAccessControlProto(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_PublicAccessControl(popr, false)
+	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership_PublicAccessControl{}
+	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	littlefuzz := make([]byte, len(dAtA))
+	copy(littlefuzz, dAtA)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+	if len(littlefuzz) > 0 {
+		fuzzamount := 100
+		for i := 0; i < fuzzamount; i++ {
+			littlefuzz[popr.Intn(len(littlefuzz))] = byte(popr.Intn(256))
+			littlefuzz = append(littlefuzz, byte(popr.Intn(256)))
+		}
+		// shouldn't panic
+		_ = github_com_gogo_protobuf_proto.Unmarshal(littlefuzz, msg)
+	}
+}
+
+func TestOwnership_PublicAccessControlMarshalTo(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_PublicAccessControl(popr, false)
+	size := p.Size()
+	dAtA := make([]byte, size)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	_, err := p.MarshalTo(dAtA)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership_PublicAccessControl{}
+	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnership_AccessControlProto(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_AccessControl(popr, false)
+	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership_AccessControl{}
+	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	littlefuzz := make([]byte, len(dAtA))
+	copy(littlefuzz, dAtA)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+	if len(littlefuzz) > 0 {
+		fuzzamount := 100
+		for i := 0; i < fuzzamount; i++ {
+			littlefuzz[popr.Intn(len(littlefuzz))] = byte(popr.Intn(256))
+			littlefuzz = append(littlefuzz, byte(popr.Intn(256)))
+		}
+		// shouldn't panic
+		_ = github_com_gogo_protobuf_proto.Unmarshal(littlefuzz, msg)
+	}
+}
+
+func TestOwnership_AccessControlMarshalTo(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_AccessControl(popr, false)
+	size := p.Size()
+	dAtA := make([]byte, size)
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	_, err := p.MarshalTo(dAtA)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership_AccessControl{}
+	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	for i := range dAtA {
+		dAtA[i] = byte(popr.Intn(256))
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
 func TestMetadataJSON(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
@@ -161,6 +329,60 @@ func TestCreateMetadataJSON(t *testing.T) {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
 	msg := &CreateMetadata{}
+	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
+	}
+}
+func TestOwnershipJSON(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership(popr, true)
+	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
+	jsondata, err := marshaler.MarshalToString(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership{}
+	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
+	}
+}
+func TestOwnership_PublicAccessControlJSON(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_PublicAccessControl(popr, true)
+	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
+	jsondata, err := marshaler.MarshalToString(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership_PublicAccessControl{}
+	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
+	}
+}
+func TestOwnership_AccessControlJSON(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_AccessControl(popr, true)
+	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
+	jsondata, err := marshaler.MarshalToString(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	msg := &Ownership_AccessControl{}
 	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
@@ -225,6 +447,90 @@ func TestCreateMetadataProtoCompactText(t *testing.T) {
 	}
 }
 
+func TestOwnershipProtoText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership(popr, true)
+	dAtA := github_com_gogo_protobuf_proto.MarshalTextString(p)
+	msg := &Ownership{}
+	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnershipProtoCompactText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership(popr, true)
+	dAtA := github_com_gogo_protobuf_proto.CompactTextString(p)
+	msg := &Ownership{}
+	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnership_PublicAccessControlProtoText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_PublicAccessControl(popr, true)
+	dAtA := github_com_gogo_protobuf_proto.MarshalTextString(p)
+	msg := &Ownership_PublicAccessControl{}
+	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnership_PublicAccessControlProtoCompactText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_PublicAccessControl(popr, true)
+	dAtA := github_com_gogo_protobuf_proto.CompactTextString(p)
+	msg := &Ownership_PublicAccessControl{}
+	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnership_AccessControlProtoText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_AccessControl(popr, true)
+	dAtA := github_com_gogo_protobuf_proto.MarshalTextString(p)
+	msg := &Ownership_AccessControl{}
+	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
+func TestOwnership_AccessControlProtoCompactText(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_AccessControl(popr, true)
+	dAtA := github_com_gogo_protobuf_proto.CompactTextString(p)
+	msg := &Ownership_AccessControl{}
+	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	if !p.Equal(msg) {
+		t.Fatalf("seed = %d, %#v !Proto %#v", seed, msg, p)
+	}
+}
+
 func TestMetadataSize(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
@@ -251,6 +557,72 @@ func TestCreateMetadataSize(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
 	p := NewPopulatedCreateMetadata(popr, true)
+	size2 := github_com_gogo_protobuf_proto.Size(p)
+	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	size := p.Size()
+	if len(dAtA) != size {
+		t.Errorf("seed = %d, size %v != marshalled size %v", seed, size, len(dAtA))
+	}
+	if size2 != size {
+		t.Errorf("seed = %d, size %v != before marshal proto.Size %v", seed, size, size2)
+	}
+	size3 := github_com_gogo_protobuf_proto.Size(p)
+	if size3 != size {
+		t.Errorf("seed = %d, size %v != after marshal proto.Size %v", seed, size, size3)
+	}
+}
+
+func TestOwnershipSize(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership(popr, true)
+	size2 := github_com_gogo_protobuf_proto.Size(p)
+	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	size := p.Size()
+	if len(dAtA) != size {
+		t.Errorf("seed = %d, size %v != marshalled size %v", seed, size, len(dAtA))
+	}
+	if size2 != size {
+		t.Errorf("seed = %d, size %v != before marshal proto.Size %v", seed, size, size2)
+	}
+	size3 := github_com_gogo_protobuf_proto.Size(p)
+	if size3 != size {
+		t.Errorf("seed = %d, size %v != after marshal proto.Size %v", seed, size, size3)
+	}
+}
+
+func TestOwnership_PublicAccessControlSize(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_PublicAccessControl(popr, true)
+	size2 := github_com_gogo_protobuf_proto.Size(p)
+	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
+	if err != nil {
+		t.Fatalf("seed = %d, err = %v", seed, err)
+	}
+	size := p.Size()
+	if len(dAtA) != size {
+		t.Errorf("seed = %d, size %v != marshalled size %v", seed, size, len(dAtA))
+	}
+	if size2 != size {
+		t.Errorf("seed = %d, size %v != before marshal proto.Size %v", seed, size, size2)
+	}
+	size3 := github_com_gogo_protobuf_proto.Size(p)
+	if size3 != size {
+		t.Errorf("seed = %d, size %v != after marshal proto.Size %v", seed, size, size3)
+	}
+}
+
+func TestOwnership_AccessControlSize(t *testing.T) {
+	seed := time.Now().UnixNano()
+	popr := math_rand.New(math_rand.NewSource(seed))
+	p := NewPopulatedOwnership_AccessControl(popr, true)
 	size2 := github_com_gogo_protobuf_proto.Size(p)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {

--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
+++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
@@ -405,10 +405,11 @@ includes_SunOS='
 #include <net/if_arp.h>
 #include <net/if_types.h>
 #include <net/route.h>
+#include <netinet/icmp6.h>
 #include <netinet/in.h>
-#include <termios.h>
 #include <netinet/ip.h>
 #include <netinet/ip_mroute.h>
+#include <termios.h>
 '
 
 
@@ -499,10 +500,10 @@ ccflags="$@"
 		$2 ~ /^LOCK_(SH|EX|NB|UN)$/ ||
 		$2 ~ /^LO_(KEY|NAME)_SIZE$/ ||
 		$2 ~ /^LOOP_(CLR|CTL|GET|SET)_/ ||
-		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|ICMP6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL)_/ ||
+		$2 ~ /^(AF|SOCK|SO|SOL|IPPROTO|IP|IPV6|TCP|MCAST|EVFILT|NOTE|SHUT|PROT|MAP|MFD|T?PACKET|MSG|SCM|MCL|DT|MADV|PR|LOCAL)_/ ||
 		$2 ~ /^TP_STATUS_/ ||
 		$2 ~ /^FALLOC_/ ||
-		$2 ~ /^ICMP(V6)?_FILTER$/ ||
+		$2 ~ /^ICMPV?6?_(FILTER|SEC)/ ||
 		$2 == "SOMAXCONN" ||
 		$2 == "NAME_MAX" ||
 		$2 == "IFNAMSIZ" ||

--- a/vendor/golang.org/x/sys/unix/zerrors_freebsd_arm.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_freebsd_arm.go
@@ -1022,6 +1022,15 @@ const (
 	MAP_RESERVED0100               = 0x100
 	MAP_SHARED                     = 0x1
 	MAP_STACK                      = 0x400
+	MCAST_BLOCK_SOURCE             = 0x54
+	MCAST_EXCLUDE                  = 0x2
+	MCAST_INCLUDE                  = 0x1
+	MCAST_JOIN_GROUP               = 0x50
+	MCAST_JOIN_SOURCE_GROUP        = 0x52
+	MCAST_LEAVE_GROUP              = 0x51
+	MCAST_LEAVE_SOURCE_GROUP       = 0x53
+	MCAST_UNBLOCK_SOURCE           = 0x55
+	MCAST_UNDEFINED                = 0x0
 	MCL_CURRENT                    = 0x1
 	MCL_FUTURE                     = 0x2
 	MNT_ACLS                       = 0x8000000

--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
@@ -974,6 +974,10 @@ const (
 	HUGETLBFS_MAGIC                             = 0x958458f6
 	IBSHIFT                                     = 0x10
 	ICMPV6_FILTER                               = 0x1
+	ICMPV6_FILTER_BLOCK                         = 0x1
+	ICMPV6_FILTER_BLOCKOTHERS                   = 0x3
+	ICMPV6_FILTER_PASS                          = 0x2
+	ICMPV6_FILTER_PASSONLY                      = 0x4
 	ICMP_FILTER                                 = 0x1
 	ICRNL                                       = 0x100
 	IFA_F_DADFAILED                             = 0x8

--- a/vendor/golang.org/x/sys/unix/zerrors_solaris_amd64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_solaris_amd64.go
@@ -366,6 +366,7 @@ const (
 	HUPCL                         = 0x400
 	IBSHIFT                       = 0x10
 	ICANON                        = 0x2
+	ICMP6_FILTER                  = 0x1
 	ICRNL                         = 0x100
 	IEXTEN                        = 0x8000
 	IFF_ADDRCONF                  = 0x80000
@@ -612,6 +613,7 @@ const (
 	IP_RECVPKTINFO                = 0x1a
 	IP_RECVRETOPTS                = 0x6
 	IP_RECVSLLA                   = 0xa
+	IP_RECVTOS                    = 0xc
 	IP_RECVTTL                    = 0xb
 	IP_RETOPTS                    = 0x8
 	IP_REUSEADDR                  = 0x104
@@ -704,6 +706,7 @@ const (
 	O_APPEND                      = 0x8
 	O_CLOEXEC                     = 0x800000
 	O_CREAT                       = 0x100
+	O_DIRECT                      = 0x2000000
 	O_DIRECTORY                   = 0x1000000
 	O_DSYNC                       = 0x40
 	O_EXCL                        = 0x400

--- a/vendor/golang.org/x/sys/unix/zerrors_zos_s390x.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_zos_s390x.go
@@ -137,6 +137,7 @@ const (
 	IP_TTL                          = 3
 	IP_UNBLOCK_SOURCE               = 11
 	ICANON                          = 0x0010
+	ICMP6_FILTER                    = 0x26
 	ICRNL                           = 0x0002
 	IEXTEN                          = 0x0020
 	IGNBRK                          = 0x0004

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
-# golang.org/x/sys v0.0.0-20210324051608-47abb6519492
+# golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57
 ## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds ownership object to Metadata section relacing the exiting Ownership (a name)

**Which issue(s) this PR fixes** (optional)
PB-1244

**Special notes for your reviewer**:
This PR would not be pushed to master till other changes in px-backup are done, doing so will break px-backup when someone vendors top of master
