### PR TITLE
Fixed scl compilation for ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,11 @@ centos:
 	curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$(PROTOC_ZIP) 
 	unzip -o $(PROTOC_ZIP) -d /usr bin/protoc
 	rm -f $(PROTOC_ZIP)
+	scl enable llvm-toolset-7 "clang-format -i $(PROTOC_FILES)"
+
 
 proto:
+	apt install clang-format
 	rm -rf ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/
 	mkdir -p ${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/
 	curl -OL https://github.com/grpc-ecosystem/grpc-gateway/archive/refs/tags/v2.2.0.tar.gz
@@ -37,7 +40,6 @@ proto:
 	mkdir -p ${GOPATH}/src/github.com/gogo/protobuf/
 	git clone git@github.com:gogo/protobuf.git ${GOPATH}/src/github.com/gogo/protobuf
 
-	scl enable llvm-toolset-7 "clang-format -i $(PROTOC_FILES)"
 	go get -u \
 	        github.com/gogo/protobuf/protoc-gen-gogo \
 	        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029 // indirect
+	google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2273,6 +2273,8 @@ google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55 h1:U1u4KB2kx6KR/aJ
 google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55/go.mod h1:45EK0dUbEZ2NHjCeAd2LXmyjAgGUGrpGROgjhC3ADck=
 google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029 h1:zS8DNtiDX68/osEpazR86KM1vnDELdnRgpK6/fwlQTs=
 google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
+google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6 h1:a2S6M0+660BgMNl++4JPlcAO/CjkqYItDEZwkoDQK7c=
+google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.15.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed compile issue on ubuntu

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

**Tested on ubuntu**
```
root@ip-10-13-110-198:~/git/go/src/github.com/portworx/px-backup-api# cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.2 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.2 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
root@ip-10-13-110-198:~/git/go/src/github.com/portworx/px-backup-
```

**Compiled on ubuntu**
```
Resolving deltas: 100% (20915/20915), done.
go get -u \
        github.com/gogo/protobuf/protoc-gen-gogo \
        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
        github.com/gogo/protobuf/protoc-gen-gogofaster \
        github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
go: module github.com/golang/protobuf is deprecated: Use the "google.golang.org/protobuf" module instead.
go get: installing executables with 'go get' in module mode is deprecated.
        To adjust and download dependencies of the current module, use 'go get -d'.
        To install using requirements of the current module, use 'go install'.
        To install ignoring the current module, use 'go install' with a version,
        like 'go install example.com/cmd@latest'.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
protoc -I/usr/local/include -I. \
        -I/root/git/go/src \
        -I/root/git/go/src/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-openapiv2 \
        -I/root/git/go/src/github.com/gogo/protobuf/protobuf \
        -I/root/git/go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
        -I/root/git/go/src/github.com/grpc-ecosystem/grpc-gateway/ \
        --gogofaster_out=\
Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto,\
Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,\
Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api,\
Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types,\
plugins=grpc:. \
        --grpc-gateway_out=allow_patch_feature=false,\
Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto,\
Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,\
Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,\
Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api,\
Mgoogle/protobuf/field_mask.proto=github.com/gogo/protobuf/types:.\
        --swagger_out=logtostderr=true:. \
        pkg/apis/v1/api.proto pkg/apis/v1/common.proto
```

