### PR TITLE
PB-7977 : Deprecating delete_backups while deleting BL or cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Do not use directly, use `make docker-build-proto` instead
 #
 
-FROM golang:1.20
+FROM golang:1.23
 ENV GOPATH=/go
 RUN mkdir -p portworx/px-backup-api
 WORKDIR portworx/px-backup-api

--- a/pkg/apis/v1/api.pb.go
+++ b/pkg/apis/v1/api.pb.go
@@ -3780,7 +3780,8 @@ type BackupInfo struct {
 	// volume snapshot class mapping for csi based backup <provisioner(string), volumesnapshotclass(string)> (optional)
 	VolumeSnapshotClassMapping map[string]string `protobuf:"bytes,37,rep,name=volume_snapshot_class_mapping,json=volumeSnapshotClassMapping,proto3" json:"volume_snapshot_class_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// option to take backup as direct kdmp
-	DirectKdmp    bool             `protobuf:"varint,38,opt,name=direct_kdmp,json=directKdmp,proto3" json:"direct_kdmp,omitempty"`
+	DirectKdmp bool `protobuf:"varint,38,opt,name=direct_kdmp,json=directKdmp,proto3" json:"direct_kdmp,omitempty"`
+	// this will store the timestamp, when the retention period of locked backup will be expired
 	RetentionTime *types.Timestamp `protobuf:"bytes,39,opt,name=retention_time,json=retentionTime,proto3" json:"retention_time,omitempty"`
 }
 
@@ -7755,6 +7756,7 @@ type ClusterDeleteRequest struct {
 	Name  string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// delete_backups indicates whether the backup related to cluster need to
 	// be deleted or retained.
+	// delete_backups is deprecated, not to be used.
 	DeleteBackups bool `protobuf:"varint,3,opt,name=delete_backups,json=deleteBackups,proto3" json:"delete_backups,omitempty"`
 	// delete_restores indicates whether the restore related to cluster  need to
 	// be deleted or retained.
@@ -10324,6 +10326,7 @@ type BackupLocationDeleteRequest struct {
 	Name  string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// delete_backups indicates whether the cloud backup files need to
 	// be deleted or retained.
+	// delete_backups is deprecated, not to be used.
 	DeleteBackups bool   `protobuf:"varint,3,opt,name=delete_backups,json=deleteBackups,proto3" json:"delete_backups,omitempty"`
 	Uid           string `protobuf:"bytes,4,opt,name=uid,proto3" json:"uid,omitempty"`
 }

--- a/pkg/apis/v1/api.proto
+++ b/pkg/apis/v1/api.proto
@@ -1295,6 +1295,7 @@ message ClusterDeleteRequest {
     string name = 2;
     // delete_backups indicates whether the backup related to cluster need to
     // be deleted or retained.
+    // delete_backups is deprecated, not to be used.
     bool delete_backups = 3;
     // delete_restores indicates whether the restore related to cluster  need to
     // be deleted or retained.
@@ -1815,6 +1816,7 @@ message BackupLocationDeleteRequest {
     string name = 2;
     // delete_backups indicates whether the cloud backup files need to
     // be deleted or retained.
+    // delete_backups is deprecated, not to be used.
     bool delete_backups = 3;
     string uid = 4;
 }

--- a/pkg/apis/v1/api.swagger.json
+++ b/pkg/apis/v1/api.swagger.json
@@ -538,7 +538,7 @@
           },
           {
             "name": "delete_backups",
-            "description": "delete_backups indicates whether the cloud backup files need to\nbe deleted or retained.",
+            "description": "delete_backups indicates whether the cloud backup files need to\nbe deleted or retained.\ndelete_backups is deprecated, not to be used.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -1166,7 +1166,7 @@
           },
           {
             "name": "delete_backups",
-            "description": "delete_backups indicates whether the backup related to cluster need to\nbe deleted or retained.",
+            "description": "delete_backups indicates whether the backup related to cluster need to\nbe deleted or retained.\ndelete_backups is deprecated, not to be used.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -3295,7 +3295,8 @@
         },
         "retention_time": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "title": "this will store the timestamp, when the retention period of locked backup will be expired"
         }
       }
     },


### PR DESCRIPTION
- delete_backups deprecated from ClusterDeleteRequest
- delete_backups deprecated from BackupLocationDeleteRequest

**What this PR does / why we need it**:
Removes the provision to delete the backups on deleting backup location or cluster by deprecating the bool parameter

**Which issue(s) this PR fixes** (optional)
Closes #PB-7977

**Special notes for your reviewer**:

