### PR TITLE
PB-7977 : Deprecating backupschedule delete_backups flag

### DIFF
--- a/pkg/apis/v1/api.pb.go
+++ b/pkg/apis/v1/api.pb.go
@@ -7015,8 +7015,7 @@ func (m *BackupScheduleInspectResponse) GetBackupSchedule() *BackupScheduleObjec
 type BackupScheduleDeleteRequest struct {
 	OrgId string `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
 	Name  string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	// delete_backups indicates whether the cloud backup files need to
-	// be deleted or retained.
+	// delete_backups is deprecated, not to be used.
 	DeleteBackups bool   `protobuf:"varint,3,opt,name=delete_backups,json=deleteBackups,proto3" json:"delete_backups,omitempty"`
 	Uid           string `protobuf:"bytes,4,opt,name=uid,proto3" json:"uid,omitempty"`
 }
@@ -7754,8 +7753,6 @@ func (m *ClusterInspectResponse) GetCluster() *ClusterObject {
 type ClusterDeleteRequest struct {
 	OrgId string `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
 	Name  string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	// delete_backups indicates whether the backup related to cluster need to
-	// be deleted or retained.
 	// delete_backups is deprecated, not to be used.
 	DeleteBackups bool `protobuf:"varint,3,opt,name=delete_backups,json=deleteBackups,proto3" json:"delete_backups,omitempty"`
 	// delete_restores indicates whether the restore related to cluster  need to
@@ -10324,8 +10321,6 @@ func (m *BackupLocationInspectResponse) GetBackupLocation() *BackupLocationObjec
 type BackupLocationDeleteRequest struct {
 	OrgId string `protobuf:"bytes,1,opt,name=org_id,json=orgId,proto3" json:"org_id,omitempty"`
 	Name  string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	// delete_backups indicates whether the cloud backup files need to
-	// be deleted or retained.
 	// delete_backups is deprecated, not to be used.
 	DeleteBackups bool   `protobuf:"varint,3,opt,name=delete_backups,json=deleteBackups,proto3" json:"delete_backups,omitempty"`
 	Uid           string `protobuf:"bytes,4,opt,name=uid,proto3" json:"uid,omitempty"`

--- a/pkg/apis/v1/api.proto
+++ b/pkg/apis/v1/api.proto
@@ -1135,8 +1135,7 @@ message BackupScheduleInspectResponse {
 message BackupScheduleDeleteRequest {
     string org_id = 1;
     string name = 2;
-    // delete_backups indicates whether the cloud backup files need to
-    // be deleted or retained.
+    // delete_backups is deprecated, not to be used.
     bool delete_backups = 3;
     string uid = 4;
 }
@@ -1293,8 +1292,6 @@ message ClusterInspectResponse { ClusterObject cluster = 1; }
 message ClusterDeleteRequest {
     string org_id = 1;
     string name = 2;
-    // delete_backups indicates whether the backup related to cluster need to
-    // be deleted or retained.
     // delete_backups is deprecated, not to be used.
     bool delete_backups = 3;
     // delete_restores indicates whether the restore related to cluster  need to
@@ -1814,8 +1811,6 @@ message BackupLocationInspectResponse {
 message BackupLocationDeleteRequest {
     string org_id = 1;
     string name = 2;
-    // delete_backups indicates whether the cloud backup files need to
-    // be deleted or retained.
     // delete_backups is deprecated, not to be used.
     bool delete_backups = 3;
     string uid = 4;

--- a/pkg/apis/v1/api.swagger.json
+++ b/pkg/apis/v1/api.swagger.json
@@ -538,7 +538,7 @@
           },
           {
             "name": "delete_backups",
-            "description": "delete_backups indicates whether the cloud backup files need to\nbe deleted or retained.\ndelete_backups is deprecated, not to be used.",
+            "description": "delete_backups is deprecated, not to be used.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -793,7 +793,7 @@
           },
           {
             "name": "delete_backups",
-            "description": "delete_backups indicates whether the cloud backup files need to\nbe deleted or retained.",
+            "description": "delete_backups is deprecated, not to be used.",
             "in": "query",
             "required": false,
             "type": "boolean",
@@ -1166,7 +1166,7 @@
           },
           {
             "name": "delete_backups",
-            "description": "delete_backups indicates whether the backup related to cluster need to\nbe deleted or retained.\ndelete_backups is deprecated, not to be used.",
+            "description": "delete_backups is deprecated, not to be used.",
             "in": "query",
             "required": false,
             "type": "boolean",


### PR DESCRIPTION
What this PR does / why we need it:
Removes the provision to delete the backups on deleting backupschedule by deprecating the bool parameter

Which issue(s) this PR fixes (optional)
Closes #PB-7977

**Special notes for your reviewer**:

