### PR TITLE
Pinning errcheck  & staticcheck version to v1.10.0 & v0.6.0 respectively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,6 @@ staticcheck:
 	staticcheck $(PKGS)
 
 errcheck:
-	go install github.com/kisielk/errcheck@latest
+	go install github.com/kisielk/errcheck@v1.10.0
 	errcheck -ignoregenerated -verbose -blank $(PKGS)
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ vet:
 	go vet $(PKGS)
 
 staticcheck:
-	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+	GOFLAGS="" go install honnef.co/go/tools/cmd/staticcheck@v0.6.0
 	staticcheck $(PKGS)
 
 errcheck:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `errcheck` target in the `Makefile` installs `github.com/kisielk/errcheck@latest`. 
As of `errcheck v1.20.0`, released on May 12, 2026 : https://pkg.go.dev/github.com/kisielk/errcheck/errcheck?tab=versions
the module requires Go `>= 1.25.0`. This causes `make errcheck` (and transitively `make docker-build-proto`) to fail with a toolchain error.

This PR pins `errcheck` to **v1.10.0**, the last release compatible with our current Go toolchain, restoring a green build until we upgrade Go.


**Before:**
```
go install github.com/kisielk/errcheck@latest
go: downloading github.com/kisielk/errcheck v1.20.0
go: github.com/kisielk/errcheck@latest: github.com/kisielk/errcheck@v1.20.0 requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)
make: *** [Makefile:78: errcheck] Error 1
make: *** [docker-build-proto] Error 2
```
<img width="1630" height="1103" alt="image" src="https://github.com/user-attachments/assets/e8845769-4273-4b93-a047-4897866eae4f" />


**After:**
```
go install github.com/kisielk/errcheck@v1.10.0
go: downloading github.com/kisielk/errcheck v1.10.0
go: downloading golang.org/x/tools v0.30.0
go: downloading golang.org/x/sync v0.11.0
go: downloading golang.org/x/mod v0.23.0
errcheck -ignoregenerated -verbose -blank github.com/portworx/px-backup-api/pkg/kubeauth github.com/portworx/px-backup-api/pkg/kubeauth/aws github.com/portworx/px-backup-api/pkg/kubeauth/gcp github.com/portworx/px-backup-api/pkg/kubeauth/ibm
checking github.com/portworx/px-backup-api/pkg/kubeauth
checking github.com/portworx/px-backup-api/pkg/kubeauth/aws
checking github.com/portworx/px-backup-api/pkg/kubeauth/gcp
checking github.com/portworx/px-backup-api/pkg/kubeauth/ibm

```
<img width="1630" height="1216" alt="image" src="https://github.com/user-attachments/assets/7c008b07-8421-485b-9ca6-2bf845fd1395" />
