### PR TITLE
PB-16470: document object_lock_enabled as backend-filled

### DIFF
--- a/pkg/apis/v1/api.proto
+++ b/pkg/apis/v1/api.proto
@@ -759,6 +759,11 @@ message BackupLocationInfo {
     //   - Cloud-specific configuration (e.g., azure_account_name, azure_subscription_id) should be
     //     provided directly in the backup location's config (e.g., S3Config).
     ObjectRef cloud_credential_ref = 8;
+    // Whether object lock is enabled on the backup location's bucket.
+    // This is a property of the bucket, not a user choice: it is filled in by the
+    // backend (derived from the bucket directly in non-federated mode, or from
+    // Stork's validation result in federated mode). Any value set in the request is
+    // ignored. Clients should treat this as read-only / output-only.
     bool object_lock_enabled = 9;
     // Workload Identity flag to identify if the backup location uses workload identity authentication.
     // Named to match Stork BackupLocation CR field: azureConfig.useWorkloadIdentity, s3Config.useWorkloadIdentity


### PR DESCRIPTION
object_lock_enabled is a property of the bucket, not a user choice. The backend always fills it in (derived from the bucket in non-federated mode, or from Stork's validation result in federated mode) and ignores any value set in the request. Document the field as read-only/output-only so clients stop passing it.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

