### PR TITLE
PB-16470: regenerate generated code for object_lock_enabled comment

### DIFF
--- a/pkg/apis/v1/api.pb.go
+++ b/pkg/apis/v1/api.pb.go
@@ -5041,7 +5041,12 @@ type BackupLocationInfo struct {
 	//   - Cloud-specific configuration (e.g., azure_account_name, azure_subscription_id) should be
 	//     provided directly in the backup location's config (e.g., S3Config).
 	CloudCredentialRef *ObjectRef `protobuf:"bytes,8,opt,name=cloud_credential_ref,json=cloudCredentialRef,proto3" json:"cloud_credential_ref,omitempty"`
-	ObjectLockEnabled  bool       `protobuf:"varint,9,opt,name=object_lock_enabled,json=objectLockEnabled,proto3" json:"object_lock_enabled,omitempty"`
+	// Whether object lock is enabled on the backup location's bucket.
+	// This is a property of the bucket, not a user choice: it is filled in by the
+	// backend (derived from the bucket directly in non-federated mode, or from
+	// Stork's validation result in federated mode). Any value set in the request is
+	// ignored. Clients should treat this as read-only / output-only.
+	ObjectLockEnabled bool `protobuf:"varint,9,opt,name=object_lock_enabled,json=objectLockEnabled,proto3" json:"object_lock_enabled,omitempty"`
 	// Workload Identity flag to identify if the backup location uses workload identity authentication.
 	// Named to match Stork BackupLocation CR field: azureConfig.useWorkloadIdentity, s3Config.useWorkloadIdentity
 	// When set to true:

--- a/pkg/apis/v1/api.swagger.json
+++ b/pkg/apis/v1/api.swagger.json
@@ -6124,7 +6124,8 @@
           "description": "Reference to the cloud credential object.\nFor Non-Federated Identity: Required for Non NFS provider.\n  - Must reference a valid CloudCredentialObject that contains the authentication credentials\n    (e.g., AzureConfig with account_name, account_key/client_secret, client_id, tenant_id, subscription_id).\n  - The cloud credential object provides the necessary authentication information to access the backup location.\nFor Federated Identity (Workload Identity): Not required, leave empty.\n  - In federated identity mode, authentication is handled via workload identity/OIDC tokens,\n    so no cloud credential object is needed.\n  - The 'type' field is still required to specify the cloud provider type (e.g., Azure, AWS, Google).\n  - Cloud-specific configuration (e.g., azure_account_name, azure_subscription_id) should be\n    provided directly in the backup location's config (e.g., S3Config)."
         },
         "object_lock_enabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether object lock is enabled on the backup location's bucket.\nThis is a property of the bucket, not a user choice: it is filled in by the\nbackend (derived from the bucket directly in non-federated mode, or from\nStork's validation result in federated mode). Any value set in the request is\nignored. Clients should treat this as read-only / output-only."
         },
         "use_workload_identity": {
           "type": "boolean",


### PR DESCRIPTION
Run make docker-build-proto to propagate the object_lock_enabled doc comment (added in #429) into the generated api.pb.go and api.swagger.json, which the proto-only change missed.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

